### PR TITLE
Add Azure Table persistence

### DIFF
--- a/src/handler.py
+++ b/src/handler.py
@@ -96,7 +96,9 @@ def handle_collection(event, context, start_time):
     # Initialize collector
     if os.environ.get('CLOUD_PROVIDER') == 'azure':
         subscription_id = os.environ.get('AZURE_SUBSCRIPTION_ID')
-        collector = AzureInventoryCollector(subscription_id)
+        table_url = os.environ.get('AZURE_TABLE_URL')
+        table_name = os.environ.get('AZURE_TABLE_NAME', 'inventory')
+        collector = AzureInventoryCollector(subscription_id, table_url, table_name)
     else:
         collector = AWSInventoryCollector(
             table_name=os.environ.get('DYNAMODB_TABLE_NAME', 'aws-inventory')

--- a/tests/unit/test_azure_collector.py
+++ b/tests/unit/test_azure_collector.py
@@ -31,6 +31,34 @@ class TestAzureInventoryCollector(unittest.TestCase):
         self.assertEqual(res['account_id'], 'sub123')
         self.assertEqual(res['region'], 'eastus')
 
+    @patch('collector.enhanced_main.TableServiceClient')
+    @patch('collector.enhanced_main.DefaultAzureCredential')
+    @patch('collector.enhanced_main.ComputeManagementClient')
+    def test_collect_inventory_persists(self, mock_compute_client, mock_cred, mock_table_service):
+        mock_vm = Mock()
+        mock_vm.id = 'vm1'
+        mock_vm.location = 'eastus'
+        mock_vm.hardware_profile.vm_size = 'Standard_B1s'
+        mock_vm.storage_profile.os_disk.os_type.value = 'Linux'
+        mock_vm.tags = {'env': 'test'}
+        mock_compute_client.return_value.virtual_machines.list_all.return_value = [mock_vm]
+
+        mock_service = Mock()
+        mock_table = Mock()
+        mock_table_service.return_value = mock_service
+        mock_service.get_table_client.return_value = mock_table
+
+        os.environ['AZURE_TABLE_URL'] = 'https://table.test'
+        os.environ['AZURE_TABLE_NAME'] = 'inventory'
+
+        collector = AzureInventoryCollector('sub123')
+        resources = collector.collect_inventory()
+
+        mock_table_service.assert_called_with(endpoint='https://table.test', credential=mock_cred.return_value)
+        mock_service.get_table_client.assert_called_with('inventory')
+        mock_table.upsert_entity.assert_called_once()
+        self.assertEqual(len(resources), 1)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- persist Azure inventory to Table Storage
- support Azure table config in handler
- test Azure table persistence

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e139554fc8332ac34c622624861f5