### PR TITLE
Add Azure network cost estimation

### DIFF
--- a/src/collector/enhanced_main.py
+++ b/src/collector/enhanced_main.py
@@ -642,6 +642,13 @@ class AzureInventoryCollector:
         self.compute_client = ComputeManagementClient(self.credential, subscription_id)
         self.table_url = table_url or os.environ.get('AZURE_TABLE_URL')
         self.table_name = table_name or os.environ.get('AZURE_TABLE_NAME', 'inventory')
+        # Simple network cost rate (per GB processed)
+        self.network_rate_per_gb = 0.01
+
+    def estimate_network_cost(self, metrics: dict) -> float:
+        """Estimate network-related costs based on data processed in GB."""
+        data_gb = metrics.get('data_processed_gb', 0)
+        return round(data_gb * self.network_rate_per_gb, 2)
 
     def collect_virtual_machines(self) -> list[dict]:
         resources = []

--- a/tests/unit/test_azure_collector.py
+++ b/tests/unit/test_azure_collector.py
@@ -31,6 +31,14 @@ class TestAzureInventoryCollector(unittest.TestCase):
         self.assertEqual(res['account_id'], 'sub123')
         self.assertEqual(res['region'], 'eastus')
 
+    @patch('collector.enhanced_main.DefaultAzureCredential')
+    @patch('collector.enhanced_main.ComputeManagementClient')
+    def test_estimate_network_cost(self, mock_compute_client, mock_cred):
+        collector = AzureInventoryCollector('sub123')
+        metrics = {'data_processed_gb': 100}
+        cost = collector.estimate_network_cost(metrics)
+        self.assertEqual(cost, 1.0)
+
     @patch('collector.enhanced_main.TableServiceClient')
     @patch('collector.enhanced_main.DefaultAzureCredential')
     @patch('collector.enhanced_main.ComputeManagementClient')


### PR DESCRIPTION
## Summary
- add network cost rate to Azure collector and implement `estimate_network_cost`
- test Azure network cost estimation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687e1a47ef988332bff7b4c90b558515