### PR TITLE
Fix unused variable warning

### DIFF
--- a/src/collector/enhanced_main.py
+++ b/src/collector/enhanced_main.py
@@ -311,7 +311,7 @@ class AWSInventoryCollector:
 
                 # Get bucket encryption
                 try:
-                    encryption = s3.get_bucket_encryption(Bucket=bucket_name)
+                    s3.get_bucket_encryption(Bucket=bucket_name)
                     bucket_info['attributes']['encryption'] = True
                 except ClientError as e:
                     if e.response['Error']['Code'] == 'ServerSideEncryptionConfigurationNotFoundError':


### PR DESCRIPTION
## Summary
- remove unused `encryption` assignment in `AWSInventoryCollector.collect_s3_buckets`

## Testing
- `pytest -q -o addopts='' tests/unit/test_enhanced_collector.py`
- `ruff check src/collector/enhanced_main.py`

------
https://chatgpt.com/codex/tasks/task_e_687e1a48ccb48332938fcee0cc3fe0e0