### PR TITLE
Mark local lambda test as integration

### DIFF
--- a/tests/test_lambda_locally.py
+++ b/tests/test_lambda_locally.py
@@ -6,7 +6,7 @@ import sys
 import os
 import pytest
 
-pytest.skip("Local integration test", allow_module_level=True)
+pytestmark = pytest.mark.integration
 
 # Add src to path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))


### PR DESCRIPTION
## Summary
- rename `tests/test_lambda_locally.py.txt` to `.py`
- mark it with `pytest.mark.integration`

## Testing
- `pytest -k "not integration" -q` *(fails: unrecognized arguments --cov)*

------
https://chatgpt.com/codex/tasks/task_e_687e24dfc5b08332819f705feb499cc1