### PR TITLE
Fix pytest-cov configuration

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ click>=8.0.0
 pandas>=1.5.0
 tabulate>=0.9.0
 pytest>=7.0.0
+pytest-cov>=4.1.0
 moto>=4.0.0
 azure-identity>=1.16.0
 azure-mgmt-compute>=34.1.0


### PR DESCRIPTION
## Summary
- add `pytest-cov` to `requirements.txt` so coverage options work
- verify `pytest -q` no longer complains about unrecognized arguments

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: respx)*

------
https://chatgpt.com/codex/tasks/task_e_687e9bc611308332b88c5ef9fa2b29cf