### PR TITLE
Fix CI for pull request checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
 
 jobs:
   lint-test:
@@ -19,14 +18,14 @@ jobs:
       - name: Ruff
         run: ruff .
       - name: Mypy
-        run: mypy src || true
+        run: mypy src
       - name: Bandit
         run: bandit -r src -c pyproject.toml
       - name: Pytest
         run: pytest -m "not aws"
 
   deploy-test:
-    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
+    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     needs: lint-test
     steps:


### PR DESCRIPTION
## Summary
- run full quality gates in CI

## Testing
- `pytest -m "not aws" -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_687e9bca6b808332b2fb45b15e9f50f1