### PR TITLE
Fix function app storage setting

### DIFF
--- a/infrastructure/function_app_appsvc.bicep
+++ b/infrastructure/function_app_appsvc.bicep
@@ -39,7 +39,7 @@ resource functionApp 'Microsoft.Web/sites@2022-09-01' = {
       appSettings: [
         {
           name: 'AzureWebJobsStorage'
-          value: storageAccount.properties.primaryEndpoints.blob
+          value: listKeys(storageAccount.id, '2022-09-01').keys[0].value
         }
         {
           name: 'COSMOS_URL'


### PR DESCRIPTION
## Summary
- fetch the storage account key instead of the endpoint when configuring the Function App

## Testing
- `python -m pytest -v` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_687e9bccc0948332b6f31297acbe65c7