### PR TITLE
Fix principalTenantId usage in delegation module

### DIFF
--- a/infrastructure/lighthouse/delegation.bicep
+++ b/infrastructure/lighthouse/delegation.bicep
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0
 param mspTenantId string
 param functionPrincipalId string
+param principalTenantId string
 
 resource customRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = {
   name: guid(subscription().id, 'InventoryReaderRole')
@@ -28,12 +29,13 @@ resource registrationDef 'Microsoft.ManagedServices/registrationDefinitions@2022
     registrationDefinitionName: 'Inventory Delegation'
     description: 'Delegation for MSP inventory function'
     managedByTenantId: mspTenantId
-    authorizations: [
-      {
-        principalId: functionPrincipalId
-        roleDefinitionId: customRole.id
-      }
-    ]
+      authorizations: [
+        {
+          principalId: functionPrincipalId
+          principalTenantId: principalTenantId
+          roleDefinitionId: customRole.id
+        }
+      ]
   }
 }
 


### PR DESCRIPTION
## Summary
- wire `principalTenantId` parameter in the lighthouse delegation module

## Testing
- `make test` *(fails: tenacity.RetryError in test_collect_single_page)*

------
https://chatgpt.com/codex/tasks/task_e_687e9bcd0be88332b454df9dcd2c4ccd