### PR TITLE
Fix dev install and run tests

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -39,5 +39,8 @@ cfn-lint>=0.83.0
 checkov>=3.0.0
 
 # AWS Tools
-awscli>=1.29.0
-azure-cli>=2.55.0
+# awscli is optional and slows down installation
+# awscli>=1.29.0
+# azure-cli pinned to 2.55.0 conflicts with azure-cosmos 4.x
+# Commented out to allow dev dependency installation without version conflicts
+# azure-cli>=2.55.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ azure-data-tables>=12.7.0
 azure-mgmt-costmanagement>=4.0.0
 azure-mgmt-resourcegraph>=8.0.0
 azure-cosmos>=4.6.0
+structlog>=24.1.0


### PR DESCRIPTION
## Summary
- avoid installing heavy CLI tools in dev requirements
- add missing structlog dependency

## Testing
- `pip install -r requirements-dev.txt`
- `make test` (fails due to a test failure but no argument parsing errors)


------
https://chatgpt.com/codex/tasks/task_e_687e9beb4df08332b824253eadb25861