### PR TITLE
Add LOG_LEVEL variable to AWS infrastructure

### DIFF
--- a/cloudformation/complete-infrastructure.yaml
+++ b/cloudformation/complete-infrastructure.yaml
@@ -38,6 +38,17 @@ Parameters:
     MinValue: 512
     MaxValue: 3008
     Description: Lambda memory in MB
+
+  LogLevel:
+    Type: String
+    Default: INFO
+    AllowedValues:
+      - DEBUG
+      - INFO
+      - WARNING
+      - ERROR
+      - CRITICAL
+    Description: Logging level for the Lambda function
   
   EnableEnhancedMonitoring:
     Type: String
@@ -248,6 +259,7 @@ Resources:
           COST_ALERT_THRESHOLD: !Ref CostAlertThreshold
           REPORTS_S3_BUCKET: !Ref ReportsBucket
           ENVIRONMENT: !Ref Environment
+          LOG_LEVEL: !Ref LogLevel
       Code:
         S3Bucket: !Ref DeploymentBucket
         S3Key: lambda-deployment.zip

--- a/cloudformation/lambda-collector.yaml
+++ b/cloudformation/lambda-collector.yaml
@@ -27,6 +27,17 @@ Parameters:
     Default: '{}'
     Description: JSON configuration for AWS accounts (optional)
 
+  LogLevel:
+    Type: String
+    Default: INFO
+    AllowedValues:
+      - DEBUG
+      - INFO
+      - WARNING
+      - ERROR
+      - CRITICAL
+    Description: Logging level for the Lambda function
+
 Resources:
   # Lambda Execution Role
   LambdaExecutionRole:
@@ -80,6 +91,7 @@ Resources:
         Variables:
           DYNAMODB_TABLE_NAME: !Ref DynamoDBTableName
           ACCOUNTS_CONFIG: !Ref AccountsConfig
+          LOG_LEVEL: !Ref LogLevel
       Code:
         ZipFile: |
           import json

--- a/infrastructure/cloudformation.yaml
+++ b/infrastructure/cloudformation.yaml
@@ -46,6 +46,17 @@ Parameters:
     Description: Schedule expression for stale resource checks
     Default: 'cron(0 6 1 * ? *)'  # Monthly on the 1st at 6 AM UTC
 
+  LogLevel:
+    Type: String
+    Default: INFO
+    AllowedValues:
+      - DEBUG
+      - INFO
+      - WARNING
+      - ERROR
+      - CRITICAL
+    Description: Logging level for the Lambda function
+
 Conditions:
   HasSlackWebhook: !Not [!Equals [!Ref SlackWebhookUrl, '']]
 
@@ -271,6 +282,7 @@ Resources:
           MONTHLY_COST_THRESHOLD: !Ref MonthlyCostThreshold
           EXTERNAL_ID: !Ref ExternalId
           CONFIG_PATH: /opt/config/accounts.json
+          LOG_LEVEL: !Ref LogLevel
       Tags:
         - Key: Application
           Value: AWS-Inventory

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -333,6 +333,7 @@ resource "aws_lambda_function" "inventory_collector" {
       COST_ALERT_THRESHOLD = var.cost_alert_threshold
       REPORTS_S3_BUCKET   = aws_s3_bucket.reports.id
       ENVIRONMENT         = var.environment
+      LOG_LEVEL           = var.log_level
     }
   }
   

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -87,6 +87,12 @@ variable "external_id" {
   default     = "inventory-collector"
 }
 
+variable "log_level" {
+  description = "Logging level for the Lambda function"
+  type        = string
+  default     = "INFO"
+}
+
 variable "tags" {
   description = "Additional tags to apply to all resources"
   type        = map(string)


### PR DESCRIPTION
## Summary
- add `LOG_LEVEL` parameter to CloudFormation templates
- include `log_level` variable for Terraform
- set `LOG_LEVEL` in Lambda environment

## Testing
- `pytest -v` *(fails: ModuleNotFoundError: No module named 'azure.mgmt.sql')*

------
https://chatgpt.com/codex/tasks/task_e_687e9bdfd0b8833291a7055fdccd2966