### PR TITLE
Fix Bicep function script references

### DIFF
--- a/infrastructure/main.bicep
+++ b/infrastructure/main.bicep
@@ -106,7 +106,7 @@ resource collectorFunction 'Microsoft.Web/sites/functions@2022-09-01' = {
           schedule: '0 0 * * * *'
         }
       ]
-      scriptFile: 'collector/index.js'
+      scriptFile: 'azure_function_main.py'
     }
   }
 }
@@ -129,7 +129,7 @@ resource queryFunction 'Microsoft.Web/sites/functions@2022-09-01' = {
           name: 'res'
         }
       ]
-      scriptFile: 'query/index.js'
+      scriptFile: 'query/enhanced_inventory_query.py'
     }
   }
 }


### PR DESCRIPTION
## Summary
- point Bicep deployment at Python entrypoints

## Testing
- `make test` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_687e9bce61688332b4f53e28c0ad2676